### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "url": "https://github.com/JacksonTian/bagpipe/issues"
   },
   "dependencies": {
-    "inherits": "git://github.com/ivshti/inherits.git"
+    "inherits": "Ivshti/inherits"
   }
 }


### PR DESCRIPTION
Package json syntax is causing failures with npm install in libraries dependent on this fork.